### PR TITLE
Show that token attr isn't a literal env var

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -29,7 +29,7 @@ terraform {
 
 # Configure the Linode Provider
 provider "linode" {
-  token = "$LINODE_TOKEN"
+  # token = "..."
 }
 
 # Create a Linode


### PR DESCRIPTION
Having the literal text there made me think I can literally put `token = "$LINODE_TOKEN"` there and it'd pick up the env variable. To use an OS env variable, you have to leave out the token attribute entirely.

Set LINODE_TOKEN environment variable and use this:
```
provider "linode" {
}
```

Or, use your actual API token and use this:
```
provider "linode" {
    token = "Your API token goes here"
}
```